### PR TITLE
memoize returned callbacks of useModal

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -351,7 +351,7 @@ export const create = <P extends Record<string, unknown>>(
       return () => {
         delete ALREADY_MOUNTED[id];
       };
-    }, [id]); //eslint-disable-line
+    }, [id, show, defaultVisible]);
 
     useEffect(() => {
       if (keepMounted) setFlags(id, { keepMounted: true });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -11,7 +11,7 @@
  * @module NiceModal
  * */
 
-import React, { useEffect, useMemo, useContext, useReducer, ReactNode } from 'react';
+import React, { useEffect, useCallback, useContext, useReducer, ReactNode } from 'react';
 
 export interface NiceModalState {
   id: string;
@@ -305,30 +305,46 @@ export function useModal(modal?: any, args?: any): any {
 
   const modalInfo = modals[mid];
 
-  return useMemo<NiceModalHandler>(
-    () => ({
-      id: mid,
-      args: modalInfo?.args,
-      visible: !!modalInfo?.visible,
-      keepMounted: !!modalInfo?.keepMounted,
-      show: (args?: Record<string, unknown>) => show(mid, args),
-      hide: () => hide(mid),
-      remove: () => remove(mid),
-      resolve: (args?: unknown) => {
-        modalCallbacks[mid]?.resolve(args);
-        delete modalCallbacks[mid];
-      },
-      reject: (args?: unknown) => {
-        modalCallbacks[mid]?.reject(args);
-        delete modalCallbacks[mid];
-      },
-      resolveHide: (args?: unknown) => {
-        hideModalCallbacks[mid]?.resolve(args);
-        delete hideModalCallbacks[mid];
-      },
-    }),
-    [mid, modalInfo?.args, modalInfo?.keepMounted, modalInfo?.visible],
+  const showCallback = useCallback(
+    (args?: Record<string, unknown>) => show(mid, args),
+    [mid]
   );
+  const hideCallback = useCallback(() => hide(mid), [mid]);
+  const removeCallback = useCallback(() => remove(mid), [mid]);
+  const resolveCallback = useCallback(
+    (args?: unknown) => {
+      modalCallbacks[mid]?.resolve(args);
+      delete modalCallbacks[mid];
+    },
+    [mid]
+  );
+  const rejectCallback = useCallback(
+    (args?: unknown) => {
+      modalCallbacks[mid]?.reject(args);
+      delete modalCallbacks[mid];
+    },
+    [mid]
+  );
+  const resolveHide = useCallback(
+    (args?: unknown) => {
+      hideModalCallbacks[mid]?.resolve(args);
+      delete hideModalCallbacks[mid];
+    },
+    [mid]
+  );
+
+  return {
+    id: mid,
+    args: modalInfo?.args,
+    visible: !!modalInfo?.visible,
+    keepMounted: !!modalInfo?.keepMounted,
+    show: showCallback,
+    hide: hideCallback,
+    remove: removeCallback,
+    resolve: resolveCallback,
+    reject: rejectCallback,
+    resolveHide,
+  };
 }
 export const create = <P extends Record<string, unknown>>(
   Comp: React.ComponentType<P>,


### PR DESCRIPTION
## Problem

Issue described in #53 is still present when calling the show handler with arguments.

The following works as desired after #54:

```tsx
const [counter, setCounter] = React.useState(0);
const userModal = useModal(UserInfoModal);
const { show } = userModal; 

React.useEffect(() => {
  if (counter >= 2) {
    show();
  }
}, [counter, show])
```

The effect doesn't cause re-rendering loop as it was before. But if we call show with a non-primitive type it would again cause an infinite re-rendering loop 😢

```tsx
const [counter, setCounter] = React.useState(0);
const userModal = useModal(UserInfoModal);
const { show } = userModal; 

React.useEffect(() => {
  if (counter >= 2) {
    show({ title: 'test' }); // <- passing some args to `show`
  }
}, [counter, show]) // <- show identity will change every time we call show with args
```

It's the same reason for it as described in #54. This time though the problem is modalInfo.args - it's an object and it will change on every render.

## Solution

- don't memoize returned object from useModal. Instead memoize just returned callbacks

Fixes #55