### PR TITLE
Fix: now NiceModal.show args TS type follows React Props type

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -212,7 +212,8 @@ type NiceModalArgs<T> = T extends keyof JSX.IntrinsicElements | React.JSXElement
   ? Partial<Omit<React.ComponentProps<T>, 'id'>>
   : Record<string, unknown>;
 
-export function show<T extends any>(modal: React.FC<any>, args?: NiceModalArgs<React.FC<any>>): Promise<T>;
+export function show<T extends any, C extends React.FC<NiceModalHocProps>>(modal: C): Promise<T>;
+export function show<T extends any, C extends React.FC<React.ComponentProps<C>>>(modal: C, args: Omit<React.ComponentProps<C>, 'id'>): Promise<T>;
 export function show<T extends any>(modal: string, args?: Record<string, unknown>): Promise<T>;
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export function show(modal: React.FC<any> | string, args?: NiceModalArgs<React.FC<any>> | Record<string, unknown>) {


### PR DESCRIPTION
This PR partially addresses [another PR](https://github.com/eBay/nice-modal-react/pull/28) and type safety of show, but only in the global object call (`NiceModal.show`), not when using a `useModal` hook return value.

I created it because it should be a simple fix (although **might be a breaking change** for someone not following the type safety here), and it's a missing puzzle item for me keeping from using the library.

Usage:
```
const MyModalWithoutProps = NiceModal.create(() => {
  const modal = useModal();
  return (
    <Modal /*other niceModal props*/>
      Greetings!
    </Modal>
  );
});

NiceModal.show(MyModalWithoutProps, { name: 'Nate' }) // does not work
NiceModal.show(MyModalWithoutProps) // works
NiceModal.show(MyModalWithoutProps, { id: 1 }) // does not work

const MyModal = NiceModal.create(({ name }: { name: string }) => {
  const modal = useModal();
  return (
    <Modal /*other niceModal props*/>
      Greetings: {name}!
    </Modal>
  );
});

NiceModal.show(MyModal, { name: 'Nate' }) // works
NiceModal.show(MyModal) // does not work
NiceModal.show(MyModal, { id: 1 }) // does not work
NiceModal.show(MyModal, { name: 'Nate', id: 1 }) // does not work
```
