### PR TITLE
perf: improve type declaration hinting

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -539,7 +539,7 @@ export const bootstrapDialog = (
   };
 };
 
-export default {
+const NiceModal = {
   Provider,
   ModalDef,
   NiceModalContext,
@@ -555,3 +555,5 @@ export default {
   muiDialog,
   bootstrapDialog,
 };
+
+export default NiceModal;


### PR DESCRIPTION
Give default export a name so that editors can give users hints when they try to import "NiceModal".

<img width="523" alt="image" src="https://user-images.githubusercontent.com/8225666/177317609-0ab2f464-ce05-4ac0-ab8a-b701189c8f50.png">
