### PR TITLE
perf: improve type inference for NiceModal.show

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -212,7 +212,7 @@ type NiceModalArgs<T> = T extends keyof JSX.IntrinsicElements | React.JSXElement
   ? Partial<Omit<React.ComponentProps<T>, 'id'>>
   : Record<string, unknown>;
 
-export function show<T extends any>(modal: React.FC<any>, args?: NiceModalArgs<React.FC<any>>): Promise<T>;
+export function show<T extends any, C extends React.FC>(modal: C, args?: Omit<React.ComponentProps<C>, 'id'>): Promise<T>;
 export function show<T extends any>(modal: string, args?: Record<string, unknown>): Promise<T>;
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export function show(modal: React.FC<any> | string, args?: NiceModalArgs<React.FC<any>> | Record<string, unknown>) {


### PR DESCRIPTION
Let `NiceModal.show` infer the props type from the modal component it receives.

<img width="507" alt="image" src="https://user-images.githubusercontent.com/8225666/177323110-18dfdce5-42c2-464b-ac34-3408a54dc051.png">

Close #67 