### PR TITLE
fix: useModal show handle no longer making every prop optional and add NiceModa.show component props generic

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -209,11 +209,12 @@ const getModalId = (modal: string | React.FC<any>): string => {
 
 /** omit id and partial all required props */
 type NiceModalArgs<T> = T extends keyof JSX.IntrinsicElements | React.JSXElementConstructor<any>
-  ? Partial<Omit<React.ComponentProps<T>, 'id'>>
+  ? Omit<React.ComponentProps<T>, 'id'>
   : Record<string, unknown>;
 
-export function show<T extends any>(modal: React.FC<any>, args?: NiceModalArgs<React.FC<any>>): Promise<T>;
+export function show<T extends any, P extends any>(modal: React.FC<P>, args?: NiceModalArgs<React.FC<P>>): Promise<T>;
 export function show<T extends any>(modal: string, args?: Record<string, unknown>): Promise<T>;
+export function show<T extends any, P extends any>(modal: string, args: P): Promise<T>;
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export function show(modal: React.FC<any> | string, args?: NiceModalArgs<React.FC<any>> | Record<string, unknown>) {
   const modalId = getModalId(modal);
@@ -275,11 +276,20 @@ const setFlags = (modalId: string, flags: Record<string, unknown>): void => {
   dispatch(setModalFlags(modalId, flags));
 };
 export function useModal(): NiceModalHandler;
-export function useModal<T extends string>(modal: T, args?: Record<string, unknown>): NiceModalHandler;
-export function useModal<T extends React.FC<any>>(
+export function useModal(modal: string, args?: Record<string, unknown>): NiceModalHandler;
+export function useModal<
+  T extends React.FC<any>,
+  ComponentProps extends NiceModalArgs<T>,
+  PreparedProps extends Partial<ComponentProps> = {},
+  RemainingProps = Omit<ComponentProps, keyof PreparedProps> & Partial<ComponentProps>
+>(
   modal: T,
-  args?: NiceModalArgs<T>,
-): NiceModalHandler<NiceModalArgs<T>>;
+  args?: PreparedProps
+): Omit<NiceModalHandler, 'show'> & {
+  show: { [K in keyof RemainingProps]: RemainingProps[K] extends Exclude<RemainingProps[keyof RemainingProps], undefined> ? K : never }[keyof RemainingProps] extends undefined
+  ? (args?: RemainingProps) => Promise<unknown>
+  : (args: RemainingProps) => Promise<unknown>
+};
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export function useModal(modal?: any, args?: any): any {
   const modals = useContext(NiceModalContext);
@@ -389,7 +399,7 @@ export const create = <P extends {}>(Comp: React.ComponentType<P>): React.FC<P &
 };
 
 // All registered modals will be rendered in modal placeholder
-export const register = <T extends React.FC<any>>(id: string, comp: T, props?: NiceModalArgs<T>): void => {
+export const register = <T extends React.FC<any>>(id: string, comp: T, props?: Partial<NiceModalArgs<T>>): void => {
   if (!MODAL_REGISTRY[id]) {
     MODAL_REGISTRY[id] = { comp, props };
   } else {


### PR DESCRIPTION
This PR addresses [this other PR](https://github.com/eBay/nice-modal-react/pull/28) where it was discussed how to make the types more flexible, but apparently the pr was discontinued.

So, based on @jakst example I created this PR.

examples:
![missing_required_modal_props](https://user-images.githubusercontent.com/61118233/177358237-a3353a08-e51f-44b3-8ddc-12ae87de1a45.png)

![required_props_prepared](https://user-images.githubusercontent.com/61118233/177358282-55a127d2-0995-4832-9e13-5f11b2a3c747.png)

I think the user should be able to pass a generic to say what props are expected.
![modal_show](https://user-images.githubusercontent.com/61118233/177358470-80afccdc-f66c-4439-aabc-54bbb1976939.png)

Here I think the user should pass the required props because, as far as I'm aware, when we add the `modal component` directly in `NiceModal.show()`, we don't have to register the modal or anything.
![show_modal_component](https://user-images.githubusercontent.com/61118233/177358762-96a8e5b0-3a42-43d1-8b16-9c5cfe8926b9.png)

