### PR TITLE
Bump @ebay/nice-modal-react from 1.0.0 to 1.2.6 in /example

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@ant-design/icons": "^4.6.4",
     "@babel/core": "7.12.3",
-    "@ebay/nice-modal-react": "^1.0.0",
+    "@ebay/nice-modal-react": "^1.2.6",
     "@material-ui/core": "^4.12.1",
     "@pmmmwh/react-refresh-webpack-plugin": "0.4.3",
     "@svgr/webpack": "5.5.0",

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -1218,10 +1218,10 @@
   resolved "https://registry.yarnpkg.com/@ctrl/tinycolor/-/tinycolor-3.4.0.tgz#c3c5ae543c897caa9c2a68630bed355be5f9990f"
   integrity sha512-JZButFdZ1+/xAfpguQHoabIXkcqRRKpMrWKBkpEZZyxfY9C1DpADFB8PEqGSTeFr135SaTRfKqGKx5xSCLI7ZQ==
 
-"@ebay/nice-modal-react@^1.0.0":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@ebay/nice-modal-react/-/nice-modal-react-1.0.1.tgz#ac5c19cc1b45377d3576e8d89ea143eece1417af"
-  integrity sha512-v/3+gQp6Qj0JBAcGqzQP3Pkhy5jA7bpcXaOsXwA44jzc+ZgztcgtfPajD3b2IWiobq8aZgDBFjOXWhKHc67C5Q==
+"@ebay/nice-modal-react@^1.2.6":
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/@ebay/nice-modal-react/-/nice-modal-react-1.2.6.tgz#1b656d1e823a668f3f75807c093b2b19728d398c"
+  integrity sha512-0TCRwvRX6Wvii4GMcoJ+Rid/htvS/9FgnhKnVTObPu+/Uzcd+PP+yElp5aUwOr1OgbdH4Ei/UQidcu9Or5KcOg==
 
 "@emotion/hash@^0.8.0":
   version "0.8.0"


### PR DESCRIPTION
While using `yarn install`, the latast version has not been downloaded, there is an runtime error cause by missing API. 