### PR TITLE
Fix useModel arguments type

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -280,7 +280,7 @@ export function useModal(modal: string, args?: Record<string, unknown>): NiceMod
 export function useModal<
   T extends React.FC<any>,
   ComponentProps extends NiceModalArgs<T>,
-  PreparedProps extends Partial<ComponentProps> = {},
+  PreparedProps extends Partial<ComponentProps>,
   RemainingProps = Omit<ComponentProps, keyof PreparedProps> & Partial<ComponentProps>,
 >(
   modal: T,


### PR DESCRIPTION
Fixed `useModal` generic type. It worked well until version 1.2.6

Before:
![image](https://user-images.githubusercontent.com/113130352/196825617-c1d0bc84-a463-4356-8b0e-c1e187b0a886.png)


Now:
![image](https://user-images.githubusercontent.com/113130352/196825076-8797e002-234a-40ab-a274-3d52aa3f4f23.png)
