### PR TITLE
Fix `useModal` default value type

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -280,17 +280,13 @@ export function useModal(modal: string, args?: Record<string, unknown>): NiceMod
 export function useModal<
   T extends React.FC<any>,
   ComponentProps extends NiceModalArgs<T>,
-  PreparedProps extends Partial<ComponentProps>,
+  PreparedProps extends Partial<ComponentProps> = {} | ComponentProps,
   RemainingProps = Omit<ComponentProps, keyof PreparedProps> & Partial<ComponentProps>,
 >(
   modal: T,
   args?: PreparedProps,
 ): Omit<NiceModalHandler, 'show'> & {
-  show: {
-    [K in keyof RemainingProps]: RemainingProps[K] extends Exclude<RemainingProps[keyof RemainingProps], undefined>
-      ? K
-      : never;
-  }[keyof RemainingProps] extends undefined
+  show: Partial<RemainingProps> extends RemainingProps
     ? (args?: RemainingProps) => Promise<unknown>
     : (args: RemainingProps) => Promise<unknown>;
 };


### PR DESCRIPTION
This PR fixes the default value of the `PreparedProps` generic type.

The `PreparedProps` generic needs an object as a default value. Without the default value object, Typescript would set all the  `modal.show()` props to optional even if they're not unless the user initially passes an object to the `useModal()`.
![image](https://user-images.githubusercontent.com/61118233/196858133-1ba75f7a-10b4-4884-9541-5fc474c8c701.png)

But if the `PreparedProps` generic has an object as a default value. Typescript couldn't possibly know the initial props that the `useModal` receives because the default value of the `PreparedProps` generic was just an object.
![image](https://user-images.githubusercontent.com/61118233/196855317-94dde268-b224-4ebd-bc73-7959b1ede258.png)

My solution was to set the `PreparedProps` generic default value to ```{} | ComponentProps```. That way, Typescript knows what props the modal receives and if they are required or optional.
![image](https://user-images.githubusercontent.com/61118233/196859539-6a09d196-463b-4981-aa69-eecc369da5be.png)
