### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,10 +104,10 @@ However, besides using id, NiceModal allows to use the modal component directly 
 
 ```bash
 # with yarn
-yarn add --dev @ebay/nice-modal-react
+yarn add @ebay/nice-modal-react
 
 # or with npm
-npm install @ebay/nice-modal-react --save-dev
+npm install @ebay/nice-modal-react
 ```
 
 ## Create Your Modal Component


### PR DESCRIPTION
Correct installation example.

_The --save-dev or -D option is used to install and save your project dependencies under the devDependencies object. Packages installed under devDependencies will be ignored when you run a production build. This will shorten the time for the build since you don't install unnecessary packages._