### PR TITLE
Rename id to modalId

### DIFF
--- a/docs/api/interfaces/NiceModalHocProps.html
+++ b/docs/api/interfaces/NiceModalHocProps.html
@@ -81,7 +81,7 @@
 							<h3>Properties</h3>
 							<ul class="tsd-index-list">
 								<li class="tsd-kind-property tsd-parent-kind-interface"><a href="NiceModalHocProps.html#defaultVisible" class="tsd-kind-icon">default<wbr>Visible</a></li>
-								<li class="tsd-kind-property tsd-parent-kind-interface"><a href="NiceModalHocProps.html#id" class="tsd-kind-icon">id</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-interface"><a href="NiceModalHocProps.html#modalId" class="tsd-kind-icon">modal<wbr>Id</a></li>
 								<li class="tsd-kind-property tsd-parent-kind-interface"><a href="NiceModalHocProps.html#keepMounted" class="tsd-kind-icon">keep<wbr>Mounted</a></li>
 							</ul>
 						</section>
@@ -101,9 +101,9 @@
 					</aside>
 				</section>
 				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-interface">
-					<a name="id" class="tsd-anchor"></a>
-					<h3>id</h3>
-					<div class="tsd-signature tsd-kind-icon">id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
+					<a name="modalId" class="tsd-anchor"></a>
+					<h3>modal<wbr>Id</h3>
+					<div class="tsd-signature tsd-kind-icon">modal<wbr>Id<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span></div>
 					<aside class="tsd-sources">
 						<ul>
 							<li>Defined in <a href="https://github.com/ebay/nice-modal-react/blob/979c283/src/index.tsx#L86">index.tsx:86</a></li>
@@ -147,7 +147,7 @@
 								<a href="NiceModalHocProps.html#defaultVisible" class="tsd-kind-icon">default<wbr>Visible</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-interface">
-								<a href="NiceModalHocProps.html#id" class="tsd-kind-icon">id</a>
+								<a href="NiceModalHocProps.html#modalId" class="tsd-kind-icon">modal<wbr>Id</a>
 							</li>
 							<li class=" tsd-kind-property tsd-parent-kind-interface">
 								<a href="NiceModalHocProps.html#keepMounted" class="tsd-kind-icon">keep<wbr>Mounted</a>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -83,7 +83,7 @@ export interface NiceModalHandler<Props = Record<string, unknown>> extends NiceM
 
 // Omit will not work if extends Record<string, unknown>, which is not needed here
 export interface NiceModalHocProps {
-  id: string;
+  modalId: string;
   defaultVisible?: boolean;
   keepMounted?: boolean;
 }
@@ -354,12 +354,12 @@ export function useModal(modal?: any, args?: any): any {
   };
 }
 export const create = <P extends {}>(Comp: React.ComponentType<P>): React.FC<P & NiceModalHocProps> => {
-  return ({ defaultVisible, keepMounted, id, ...props }) => {
-    const { args, show } = useModal(id);
+  return ({ defaultVisible, keepMounted, modalId, ...props }) => {
+    const { args, show } = useModal(modalId);
 
     // If there's modal state, then should mount it.
     const modals = useContext(NiceModalContext);
-    const shouldMount = !!modals[id];
+    const shouldMount = !!modals[modalId];
 
     useEffect(() => {
       // If defaultVisible, show it after mounted.
@@ -367,18 +367,18 @@ export const create = <P extends {}>(Comp: React.ComponentType<P>): React.FC<P &
         show();
       }
 
-      ALREADY_MOUNTED[id] = true;
+      ALREADY_MOUNTED[modalId] = true;
 
       return () => {
-        delete ALREADY_MOUNTED[id];
+        delete ALREADY_MOUNTED[modalId];
       };
-    }, [id, show, defaultVisible]);
+    }, [modalId, show, defaultVisible]);
 
     useEffect(() => {
-      if (keepMounted) setFlags(id, { keepMounted: true });
-    }, [id, keepMounted]);
+      if (keepMounted) setFlags(modalId, { keepMounted: true });
+    }, [modalId, keepMounted]);
 
-    const delayVisible = modals[id]?.delayVisible;
+    const delayVisible = modals[modalId]?.delayVisible;
     // If modal.show is called
     //  1. If modal was mounted, should make it visible directly
     //  2. If modal has not been mounted, should mount it first, then make it visible
@@ -391,7 +391,7 @@ export const create = <P extends {}>(Comp: React.ComponentType<P>): React.FC<P &
 
     if (!shouldMount) return null;
     return (
-      <NiceModalIdContext.Provider value={id}>
+      <NiceModalIdContext.Provider value={modalId}>
         <Comp {...(props as P)} {...args} />
       </NiceModalIdContext.Provider>
     );


### PR DESCRIPTION
`NiceModalHocProps` has a field named `id`. This is too common and prevents us to pass a type with id on it. I've changed it to `modalId` which is more convenient IMHO.