### PR TITLE
Add ability to resolve/reject and hide

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -79,6 +79,16 @@ export interface NiceModalHandler<Props = Record<string, unknown>> extends NiceM
    * Resolve the promise returned by {@link NiceModalHandler.hide | hide} method.
    */
   resolveHide: (args?: unknown) => void;
+
+  /**
+   * Runs {@link NiceModalHandler.resolve} followed by {@link NiceModalHandler.hide}
+   */
+  resolveAndHide: (args?: unknown) => void;
+
+  /**
+   * Runs {@link NiceModalHandler.reject} followed by {@link NiceModalHandler.hide}
+   */
+  rejectAndHide: (args?: unknown) => void;
 }
 
 // Omit will not work if extends Record<string, unknown>, which is not needed here
@@ -339,6 +349,20 @@ export function useModal(modal?: any, args?: any): any {
     },
     [mid],
   );
+  const resolveAndHide = useCallback(
+    (args?: unknown) => {
+      resolveCallback(args);
+      hideCallback();
+    },
+    [resolveCallback, hideCallback],
+  );
+  const rejectAndHide = useCallback(
+    (args?: unknown) => {
+      rejectCallback(args);
+      hideCallback();
+    },
+    [resolveCallback, hideCallback],
+  );
 
   return {
     id: mid,
@@ -351,6 +375,8 @@ export function useModal(modal?: any, args?: any): any {
     resolve: resolveCallback,
     reject: rejectCallback,
     resolveHide,
+    resolveAndHide,
+    rejectAndHide,
   };
 }
 export const create = <P extends {}>(Comp: React.ComponentType<P>): React.FC<P & NiceModalHocProps> => {


### PR DESCRIPTION
Hey team,

Loving the library and I found that I often would call resolve and hide or reject and hide, and noticed that there was a similar pattern mentioned in #88 

This would mean that users are able to do something like:
```tsx
const {resolveAndHide} = useModal()

return (
  <Modal onClose={() => resolveAndHide(false)}>
   <p>Content</p>
  </Modal>
)
```

Happy to update with any feedback

Reason for creating new methods was to keep backwards compatibility 