### PR TITLE
Improve typing of show function

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -211,7 +211,7 @@ const getModalId = (modal: string | React.FC<any>): string => {
 type NiceModalArgs<T> = T extends keyof JSX.IntrinsicElements | React.JSXElementConstructor<any>
   ? Omit<React.ComponentProps<T>, 'id'>
   : Record<string, unknown>;
-export function show<T extends any>(modal: React.FC<any>, args?: NiceModalArgs<React.FC<any>>): Promise<T>;
+export declare function show<T extends any, C extends any>(modal: React.FC<C>, args?: NiceModalArgs<React.FC<C>>): Promise<T>;
 // export function show<T extends any, C extends React.FC>(modal: C, args?: Omit<React.ComponentProps<C>, 'id'>): Promise<T>;
 export function show<T extends any>(modal: string, args?: Record<string, unknown>): Promise<T>;
 export function show<T extends any, P extends any>(modal: string, args: P): Promise<T>;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -211,7 +211,7 @@ const getModalId = (modal: string | React.FC<any>): string => {
 type NiceModalArgs<T> = T extends keyof JSX.IntrinsicElements | React.JSXElementConstructor<any>
   ? Omit<React.ComponentProps<T>, 'id'>
   : Record<string, unknown>;
-export declare function show<T extends any, C extends any>(modal: React.FC<C>, args?: NiceModalArgs<React.FC<C>>): Promise<T>;
+export function show<T extends any, C extends any>(modal: React.FC<C>, args?: NiceModalArgs<React.FC<C>>): Promise<T>;
 // export function show<T extends any, C extends React.FC>(modal: C, args?: Omit<React.ComponentProps<C>, 'id'>): Promise<T>;
 export function show<T extends any>(modal: string, args?: Record<string, unknown>): Promise<T>;
 export function show<T extends any, P extends any>(modal: string, args: P): Promise<T>;


### PR DESCRIPTION
The `show` function doesn't infer the types of the modal you are passing as first parameter. By passing a generic we can do so :surfer: