### PR TITLE
Allow setting ResolveType to pass to show method

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -282,13 +282,14 @@ export function useModal<
   ComponentProps extends NiceModalArgs<T>,
   PreparedProps extends Partial<ComponentProps> = {} | ComponentProps,
   RemainingProps = Omit<ComponentProps, keyof PreparedProps> & Partial<ComponentProps>,
+  ResolveType = unknown
 >(
   modal: T,
   args?: PreparedProps,
 ): Omit<NiceModalHandler, 'show'> & {
   show: Partial<RemainingProps> extends RemainingProps
-    ? (args?: RemainingProps) => Promise<unknown>
-    : (args: RemainingProps) => Promise<unknown>;
+    ? (args?: RemainingProps) => Promise<ResolveType>
+    : (args: RemainingProps) => Promise<ResolveType>;
 };
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export function useModal(modal?: any, args?: any): any {


### PR DESCRIPTION
I spent quite some time trying to find how to type the the response of the show and couldn't manage that.
- I tried to add the type directly to the response, as shown in the attached image.
- I tried to set it inside the modal:  `modal.resolve({ msg: "here" } as ConfirmationDialogResponse)`

Nothing seemed to make it.

With this PR, we are adding an optional `ResolveType` for the `useModal` hook, which will pass the type to the Promise resolution of the `show` method. Otherwise, it will default to unknown as before.

![2023-02-03_20h36_01](https://user-images.githubusercontent.com/28725146/216680949-f4bd1ff4-91d2-41b5-8b4f-662c5344aa56.png)
