### PR TITLE
Support multiple nested context

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -445,9 +445,14 @@ const NiceModalPlaceholder: React.FC = () => {
 };
 
 const InnerContextProvider: React.FC = ({ children }) => {
-  const arr = useReducer(reducer, initialState);
-  const modals = arr[0];
-  dispatch = arr[1];
+  const [modals, givenDispatch] = useReducer(reducer, initialState);
+  useEffect(() => {
+    const currentDispatch = dispatch;
+    dispatch = givenDispatch;
+    return () => {
+      dispatch = currentDispatch;
+    };
+  }, [givenDispatch]);
   return (
     <NiceModalContext.Provider value={modals}>
       {children}
@@ -465,10 +470,17 @@ export const Provider: React.FC<Record<string, unknown>> = ({
   dispatch?: React.Dispatch<NiceModalAction>;
   modals?: NiceModalStore;
 }) => {
+  useEffect(() => {
+    if (!givenDispatch) return;
+    const currentDispatch = dispatch;
+    dispatch = givenDispatch;
+    return () => {
+      dispatch = currentDispatch;
+    };
+  }, [givenDispatch]);
   if (!givenDispatch || !givenModals) {
     return <InnerContextProvider>{children}</InnerContextProvider>;
   }
-  dispatch = givenDispatch;
   return (
     <NiceModalContext.Provider value={givenModals}>
       {children}


### PR DESCRIPTION
Hi, thank you for providing this awesome library.
I'm using nice-modal to display modal in react-native.

In some cases, I need to nest multiple `NiceModal.Provider` to support multiple screens (It's common to nest contexts when using `react-navigation`: navigation library of react-native).

In the case, since `dispatch` function is updated on every render phase, nice modal state update doesn't work properly.

With my change, `dispatch` function is updated only when component is mounted. If there were already existing `dispatch` assigned, it saves the previous value and restore it when component is going to be unmouted. By doing this, we can use child-most NiceModalContext's `dispatch` every time.

Let me know if this change is anti-pattern or breaking change for your case!