### PR TITLE
Fix type of create function for interfaces

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -377,7 +377,7 @@ export function useModal(modal?: any, args?: any): any {
     ],
   );
 }
-export const create = <P extends Record<string, unknown>>(
+export const create = <P extends {}>(
   Comp: React.ComponentType<P>,
 ): React.FC<P & NiceModalHocProps> => {
   return ({ defaultVisible, keepMounted, id, ...props }) => {


### PR DESCRIPTION
I was hit with interesting type of regression after updating lib from version 1.2.8
After some investigation I found, that interface are not legal extension of Record<string, unknown>, and this is by design (per https://github.com/microsoft/TypeScript/issues/15300#issuecomment-332366024), since they are potential target of interface merge
Since I don't see any real improvement over `P extends {}` I thought it would be better to revert this particular change
![image](https://github.com/eBay/nice-modal-react/assets/17837320/ce542c34-b427-4a9e-a396-4a98303b3827)
![image](https://github.com/eBay/nice-modal-react/assets/17837320/bd9a81df-7e02-44cf-845a-d86a463a5268)
