### PR TITLE
fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ With NiceModal you can create a separate modal component easily. It's just the s
 import { Modal } from 'antd';
 import NiceModal, { useModal } from '@ebay/nice-modal-react';
 
-export default NiceModal.create(({ name }) => {
+export default NiceModal.create(({ name }: { name: string }) => {
   // Use a hook to manage the modal state
   const modal = useModal();
   return (


### PR DESCRIPTION
fix demo in README, otherwise an error will be reported

```
No overload matches this call.
  Overload 1 of 3, '(modal: FC<NiceModalHocProps>, args?: Partial<NiceModalHocProps & { children?: ReactNode; }>): Promise<unknown>', gave the following error.
    Argument of type '{ name: any; }' is not assignable to parameter of type 'Partial<NiceModalHocProps & { children?: ReactNode; }>'.
      Object literal may only specify known properties, and 'name' does not exist in type 'Partial<NiceModalHocProps & { children?: ReactNode; }>'.
  Overload 2 of 3, '(modal: string, args?: Record<string, unknown>): Promise<unknown>', gave the following error.
    Argument of type 'FC<NiceModalHocProps>' is not assignable to parameter of type 'string'.
  Overload 3 of 3, '(modal: string, args: { name: any; }): Promise<unknown>', gave the following error.
    Argument of type 'FC<NiceModalHocProps>' is not assignable to parameter of type 'string'.
```