### PR TITLE
Make component and props' types optional in the standalone show function

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -219,10 +219,11 @@ type NiceModalArgs<T> = T extends keyof JSX.IntrinsicElements | React.JSXElement
   ? React.ComponentProps<T>
   : Record<string, unknown>;
 
-export function show<T extends any, C extends any, P extends Partial<NiceModalArgs<React.FC<C>>>>(
-  modal: React.FC<C>,
-  args?: P,
-): Promise<T>;
+export function show<
+  T extends any,
+  C extends any = any,
+  P extends Partial<NiceModalArgs<React.FC<C>>> = Partial<NiceModalArgs<React.FC<C>>>,
+>(modal: React.FC<C>, args?: P): Promise<T>;
 
 export function show<T extends any>(modal: string, args?: Record<string, unknown>): Promise<T>;
 export function show<T extends any, P extends any>(modal: string, args: P): Promise<T>;


### PR DESCRIPTION
This PR simplifies specifying type of the resolved value from the `show` function. Currently, if you want to provide a precise type of the value resolved from a promise, you'll need to provide 1/2 additional types – depending on whether you use an ID or a modal reference.

Before:
```tsx
NiceModal.show<TypeOfTheValue, ComponentType, PropsType>(SomeModal, someProps).then((value) => { ... });
```

Both `ComponentType` and `PropsType` can be automatically inferred by TS, so having to type them all each time you want to provide `TypeOfTheValue` is a bit inconvenient.

After:
```tsx
NiceModal.show<TypeOfTheValue>(SomeModal, someProps).then((value) => { ... });
```

Now you can provide just the first type while the rest gets inferred. Let me know what you think.